### PR TITLE
Fixed variable name in tutorial to match code examples.

### DIFF
--- a/comb_lock.md
+++ b/comb_lock.md
@@ -135,7 +135,7 @@ Next, you need to create a loop which will continue until the `code` list has be
        sense.set_pixel(0,0,g)
    else:
        code = complete + code
-       steps = []
+       complete = []
        sense.set_pixel(0,0,r)
      ```
 

--- a/comb_lock.md
+++ b/comb_lock.md
@@ -137,7 +137,7 @@ Next, you need to create a loop which will continue until the `code` list has be
        code = complete + code
        complete = []
        sense.set_pixel(0,0,r)
-     ```
+  ```
 
 1. Finally, you'll need to add some `sleep` commands to give the user time to rotate their Sense HAT. Using two sleep commands and turning the LED off in between will create a flashing LED that informs the user whether they've got the steps correct.
 


### PR DESCRIPTION
The code in the tutorial is inconsistent and doesn't work properly for the student.  This fix makes it match the tutorial match the example code.